### PR TITLE
Less shouty default image caption

### DIFF
--- a/src/frontend/screens/compose/model.ts
+++ b/src/frontend/screens/compose/model.ts
@@ -87,7 +87,7 @@ export default function model(
             separator = Array(addLines + 1).join('\n');
           }
 
-          const imgMarkdown = `![CAPTIONS FOR THE VISUALLY IMPAIRED](${blobId})`;
+          const imgMarkdown = `![image](${blobId})`;
 
           return {
             ...prev,


### PR DESCRIPTION
When using mobile in, say, a protest environment - having the caption shout out like this isn't what I want it to do by default